### PR TITLE
Use 'mlxfwmanager -l' for extracting available firmware version from …

### DIFF
--- a/platform/mellanox/mlnx-fw-upgrade.j2
+++ b/platform/mellanox/mlnx-fw-upgrade.j2
@@ -19,9 +19,11 @@ declare -r EXIT_SUCCESS="0"
 declare -r EXIT_FAILURE="1"
 
 declare -r QUERY_CMD="mlxfwmanager --query"
+declare -r LIST_CONTENT_CMD="mlxfwmanager -l"
 declare -r BURN_CMD="mlxfwmanager -u -f -y"
 
 declare -r QUERY_FILE="/tmp/mlxfwmanager-query.log"
+declare -r LIST_CONTENT_FILE="/tmp/list-content.log"
 
 declare -r SPC1_ASIC="spc1"
 declare -r SPC2_ASIC="spc2"
@@ -32,11 +34,6 @@ declare -rA FW_FILE_MAP=( \
     [$SPC1_ASIC]="/etc/mlnx/fw-SPC.mfa" \
     [$SPC2_ASIC]="/etc/mlnx/fw-SPC2.mfa" \
     [$SPC3_ASIC]="/etc/mlnx/fw-SPC3.mfa" \
-)
-declare -rA FW_REQUIRED_MAP=( \
-    [$SPC1_ASIC]="{{ MLNX_SPC_FW_VERSION }}" \
-    [$SPC2_ASIC]="{{ MLNX_SPC2_FW_VERSION }}" \
-    [$SPC3_ASIC]="{{ MLNX_SPC3_FW_VERSION }}" \
 )
 
 IMAGE_UPGRADE="${NO_PARAM}"
@@ -180,25 +177,23 @@ function UpgradeFW() {
 
     if [ ! -z "${_FS_MOUNTPOINT}" ]; then
         local -r _FW_FILE="${_FS_MOUNTPOINT}/${FW_FILE_MAP[$_ASIC_TYPE]}"
-
-        if [ ! -f "${_FW_FILE}" ]; then
-            ExitFailure "no such file: ${_FW_FILE}"
-        fi
-
-        RunCmd "${QUERY_CMD} -i ${_FW_FILE} -L ${QUERY_FILE}" &>/dev/null
-
-        local -r _FW_INFO="$(grep FW ${QUERY_FILE})"
-        local -r _FW_CURRENT="$(echo ${_FW_INFO} | cut -f2 -d' ')"
-        local -r _FW_AVAILABLE="$(echo ${_FW_INFO} | cut -f3 -d' ')"
     else
         local -r _FW_FILE="${FW_FILE_MAP[$_ASIC_TYPE]}"
-
-        RunCmd "${QUERY_CMD} -L ${QUERY_FILE}" &>/dev/null
-
-        local -r _FW_INFO="$(grep FW ${QUERY_FILE})"
-        local -r _FW_CURRENT="$(echo ${_FW_INFO} | cut -f2 -d' ')"
-        local -r _FW_AVAILABLE="${FW_REQUIRED_MAP[$_ASIC_TYPE]}"
     fi
+
+    if [ ! -f "${_FW_FILE}" ]; then
+        ExitFailure "no such file: ${_FW_FILE}"
+    fi
+
+    RunCmd "${QUERY_CMD} -L ${QUERY_FILE}" &>/dev/null
+    local -r _FW_INFO="$(grep FW ${QUERY_FILE})"
+    local -r _PSID_INFO="$(grep PSID ${QUERY_FILE})"
+    local -r _PSID="$(echo ${_PSID_INFO} | cut -f2 -d' ')"
+    local -r _FW_CURRENT="$(echo ${_FW_INFO} | cut -f2 -d' ')"
+
+    RunCmd "${LIST_CONTENT_CMD} -i ${_FW_FILE} > ${LIST_CONTENT_FILE}"
+    local -r _FW_AVAILABLE_INFO="$(grep ${_PSID} ${LIST_CONTENT_FILE})"
+    local -r _FW_AVAILABLE="$(echo ${_FW_AVAILABLE_INFO} | cut -f4 -d' ')"
 
     if [[ -z "${_FW_CURRENT}" ]]; then
         ExitFailure "could not retreive current FW version"


### PR DESCRIPTION
…FW images

Signed-off-by: Andriy Yurkiv <ayurkiv@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->
 closes #2336467
**- Why I did it**
in case of non-GA FW (for example 13.2008.1918-006) **mlxfwmanager** shows version in following notation:
"13_2008_1918-006" instead of "13.2008.1918-006". Because of this there was a problem while upgrading FW. Script was not able to handle new notation properly and compare new version with existing one.

**- How I did it**
Previously FW version has been taken from Makefile. But this approach can not handle problem with notation described above.
I have decided to extract FW version from FW image directly using **"mlxfwmanager -l -i <fw-some-version.EVB.mfa>"** and then using "grep" with PSID. This is quick and safe method.


**- How to verify it**
First scenario

1) install FW 13.2008.1918-006 or with similar notation using script /usr/bin/mlnx-fw-upgrade.sh :
-- copy new fw to **/etc/mlnx/fw<spectrum#>**
-- run /usr/bin/mlnx-fw-upgrade.sh -v and check current version with **mlxfwmanager --query**
**NOTE** make sure that fw correspond appropriate spectrum version
2) reboot and try install this version one more time - receive message - INFO: firmware is up to date

Second scenario:
1)Install sonic-mellanox.bin with FW mentioned above and check current version with **mlxfwmanager --query**
2)reboot and try install this version one more time **/usr/bin/mlnx-fw-upgrade.sh -v** - receive message - INFO: firmware is up to date

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
