### PR TITLE
Enable SAI_INGRESS_PRIORITY_GROUP_STAT_DROPPED_PACKETS counter by default

### DIFF
--- a/dockers/docker-orchagent/enable_counters.py
+++ b/dockers/docker-orchagent/enable_counters.py
@@ -16,6 +16,7 @@ def enable_counters():
     enable_counter_group(db, 'QUEUE')
     enable_counter_group(db, 'PFCWD')
     enable_counter_group(db, 'PG_WATERMARK')
+    enable_counter_group(db, 'PG_DROP')
     enable_counter_group(db, 'QUEUE_WATERMARK')
     enable_counter_group(db, 'BUFFER_POOL_WATERMARK')
     enable_counter_group(db, 'PORT_BUFFER_DROP')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Need to enable counter by default

**- How I did it**
add appropriate line that enable counter to dockers/docker-orchagent/enable_counters.py

**- How to verify it**
run `counterpoll show` 
you will see PG_STAT_DROP enabled there

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [ ] 202006
- [ ] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
