### PR TITLE
[devices][hwsku] add support to VXLAN src port range feature

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/sai.profile
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/sai.profile
@@ -1,1 +1,2 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/sai_2700_48x50g_8x100g.xml
+SAI_VXLAN_SRCPORT_RANGE_ENABLE=1

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-C64/sai.profile
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-C64/sai.profile
@@ -1,1 +1,2 @@
-../ACS-MSN3800/sai.profile
+SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/sai_3800.xml
+SAI_VXLAN_SRCPORT_RANGE_ENABLE=1

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D28C50/sai.profile
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D28C50/sai.profile
@@ -1,1 +1,2 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/sai_3800_28x50g_52x100g.xml
+SAI_VXLAN_SRCPORT_RANGE_ENABLE=1


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
Signed-off-by: Andriy Yurkiv ayurkiv@nvidia.com

#### Why I did it
We need to enable VXLAN src port range feature on the following HWSKU:
3800s:
•	Mellanox-SN3800-D28C50
•	Mellanox-SN3800-C64
2700:
•	Mellanox-SN2700-D48C8

#### How I did it
Added ```SAI_VXLAN_SRCPORT_RANGE_ENABLE=1``` configuration to appropriate sai.profile

#### How to verify it
Use testbed with one of supported SKU  and run following test :
```
py.test vxlan/test_vnet_vxlan.py --inventory "../ansible/inventory, ../ansible/veos" --host-pattern (testbed)-t0 --module-path                ../ansible/library/ --testbed (testbed)-t0 --testbed_file ../ansible/testbed.csv --allow_recover  --assert plain --log-cli-level info --show-capture=no -ra --showlocals --disable_loganalyzer --skip_sanity --upper_bound_udp_port 65535  --lower_bound_udp_port 64128
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

