### PR TITLE
[Mellanox][VXLAN] add params to vxlan.json file in order to configure VXLAN src port range feature

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/sai.profile
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/sai.profile
@@ -1,4 +1,3 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/sai_2700_48x50g_8x100g.xml
-SAI_VXLAN_SRCPORT_RANGE_ENABLE=1
 SAI_DUMP_STORE_PATH=/var/log/mellanox/sdk-dumps
 SAI_DUMP_STORE_AMOUNT=10

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-C64/sai.profile
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-C64/sai.profile
@@ -1,4 +1,3 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/sai_3800.xml
-SAI_VXLAN_SRCPORT_RANGE_ENABLE=1
 SAI_DUMP_STORE_PATH=/var/log/mellanox/sdk-dumps
 SAI_DUMP_STORE_AMOUNT=10

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D28C49S1/sai.profile
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D28C49S1/sai.profile
@@ -1,4 +1,3 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/sai_3800_1x10g_28x50g_49x100g.xml
-SAI_VXLAN_SRCPORT_RANGE_ENABLE=1
 SAI_DUMP_STORE_PATH=/var/log/mellanox/sdk-dumps
 SAI_DUMP_STORE_AMOUNT=10

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D28C50/sai.profile
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D28C50/sai.profile
@@ -1,4 +1,3 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/sai_3800_28x50g_52x100g.xml
-SAI_VXLAN_SRCPORT_RANGE_ENABLE=1
 SAI_DUMP_STORE_PATH=/var/log/mellanox/sdk-dumps
 SAI_DUMP_STORE_AMOUNT=10

--- a/dockers/docker-orchagent/docker-init.sh
+++ b/dockers/docker-orchagent/docker-init.sh
@@ -8,6 +8,7 @@ CFGGEN_PARAMS=" \
     -d \
     -y /etc/sonic/constants.yml \
     -t /usr/share/sonic/templates/switch.json.j2,/etc/swss/config.d/switch.json \
+    -t /usr/share/sonic/templates/vxlan.json.j2,/etc/swss/config.d/vxlan.json \
     -t /usr/share/sonic/templates/ipinip.json.j2,/etc/swss/config.d/ipinip.json \
     -t /usr/share/sonic/templates/ports.json.j2,/etc/swss/config.d/ports.json \
     -t /usr/share/sonic/templates/vlan_vars.j2 \

--- a/dockers/docker-orchagent/swssconfig.sh
+++ b/dockers/docker-orchagent/swssconfig.sh
@@ -58,7 +58,7 @@ if [[ "$SYSTEM_WARM_START" == "true" ]] || [[ "$SWSS_WARM_START" == "true" ]]; t
   exit 0
 fi
 
-SWSSCONFIG_ARGS="ipinip.json ports.json switch.json "
+SWSSCONFIG_ARGS="ipinip.json ports.json switch.json vxlan.json"
 
 for file in $SWSSCONFIG_ARGS; do
     swssconfig /etc/swss/config.d/$file

--- a/dockers/docker-orchagent/vxlan.json.j2
+++ b/dockers/docker-orchagent/vxlan.json.j2
@@ -1,0 +1,11 @@
+[
+    {
+        "SWITCH_TABLE:switch": {
+{% if DEVICE_METADATA.localhost.vxlan_port_range == 'enable' %}
+            "vxlan_sport": "0xFF00",
+            "vxlan_mask": "8"
+{% endif %}
+        },
+        "OP": "SET"
+    }
+]

--- a/rules/sonic-config.dep
+++ b/rules/sonic-config.dep
@@ -4,7 +4,7 @@ SPATH       := $($(SONIC_CONFIG_ENGINE_PY3)_SRC_PATH)
 DEP_FILES   := $(SONIC_COMMON_FILES_LIST) rules/sonic-config.mk rules/sonic-config.dep   
 DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
 DEP_FILES   += $(shell git ls-files $(SPATH))
-DEP_FILES   += files/image_config/interfaces/interfaces.j2 dockers/docker-orchagent/ports.json.j2 dockers/docker-dhcp-relay/wait_for_intf.sh.j2 dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2 dockers/docker-lldp/lldpd.conf.j2 dockers/docker-orchagent/ipinip.json.j2 $(wildcard device/arista/x86_64-arista_7050_qx32s/Arista-7050-QX-32S/*.j2 device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/*.j2) files/build_templates/qos_config.j2 dockers/docker-orchagent/switch.json.j2 files/image_config/constants/constants.yml
+DEP_FILES   += files/image_config/interfaces/interfaces.j2 dockers/docker-orchagent/ports.json.j2 dockers/docker-dhcp-relay/wait_for_intf.sh.j2 dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2 dockers/docker-lldp/lldpd.conf.j2 dockers/docker-orchagent/ipinip.json.j2 $(wildcard device/arista/x86_64-arista_7050_qx32s/Arista-7050-QX-32S/*.j2 device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/*.j2) files/build_templates/qos_config.j2 dockers/docker-orchagent/switch.json.j2 dockers/docker-orchagent/vxlan.json.j2 files/image_config/constants/constants.yml
 
 ifeq ($(ENABLE_PY2_MODULES), y)
     $(SONIC_CONFIG_ENGINE_PY2)_CACHE_MODE  := GIT_CONTENT_SHA 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
- Remove obsolete config that enable  static VXLAN src port range

Done for 
SN3800:
• Mellanox-SN3800-D28C50
• Mellanox-SN3800-C64
• Mellanox-SN3800-D28C49S1 (New 10G SKU)

SN2700:
• Mellanox-SN2700-D48C8

#### How I did it
- Remove SAI_VXLAN_SRCPORT_RANGE_ENABLE=1 from appropriate **sai.profile** files
- Created vxlan.json file and added few params that depends on DEVICE_METADATA.localhost.vxlan_port_range


#### How to verify it
File **/etc/swss/config.d/vxlan.json**  should be generated inside swss docker when it restart

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

