### PR TITLE
[mellanox][vxlan] remove old static config for VXLAN src port range feature

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D100C12S2/sai.profile
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D100C12S2/sai.profile
@@ -1,2 +1,1 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/sai_3800_2x10g_100x50g_12x100g.xml
-SAI_VXLAN_SRCPORT_RANGE_ENABLE=1

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D112C8/sai.profile
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D112C8/sai.profile
@@ -1,4 +1,3 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/sai_3800_112x50g_8x100g.xml
-SAI_VXLAN_SRCPORT_RANGE_ENABLE=1
 SAI_DUMP_STORE_PATH=/var/log/mellanox/sdk-dumps
 SAI_DUMP_STORE_AMOUNT=10

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/sai.profile
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/sai.profile
@@ -1,4 +1,3 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/sai_4600C.xml
-SAI_VXLAN_SRCPORT_RANGE_ENABLE=1
 SAI_DUMP_STORE_PATH=/var/log/mellanox/sdk-dumps
 SAI_DUMP_STORE_AMOUNT=10

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D100C12S2/sai.profile
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D100C12S2/sai.profile
@@ -1,4 +1,3 @@
-SAI_VXLAN_SRCPORT_RANGE_ENABLE=1
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/sai_4600c_100x50g_12x100g_2x10g.xml
 SAI_DUMP_STORE_PATH=/var/log/mellanox/sdk-dumps
 SAI_DUMP_STORE_AMOUNT=10

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D48C40/sai.profile
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D48C40/sai.profile
@@ -1,4 +1,3 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/sai_4600c_48x50g_40x100g.xml
 SAI_DUMP_STORE_PATH=/var/log/mellanox/sdk-dumps
 SAI_DUMP_STORE_AMOUNT=10
-SAI_VXLAN_SRCPORT_RANGE_ENABLE=1


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Need to remove old static configs from sai.profile files.

#### How I did it
remove SAI_VXLAN_SRCPORT_RANGE_ENABLE=1  lines from files per HWSKU

#### How to verify it
When static config is removed folloving test will fail

`py.test vxlan/test_vnet_vxlan.py --inventory "../ansible/inventory, ../ansible/veos" --host-pattern (testbed)-t0 --module-path                ../ansible/library/ --testbed (testbed)-t0 --testbed_file ../ansible/testbed.csv --allow_recover  --assert plain --log-cli-level info --show-capture=no -ra --showlocals --disable_loganalyzer --skip_sanity --upper_bound_udp_port 65535  --lower_bound_udp_port 64128`

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

