### PR TITLE
[enable_counters] Set default values only on the first start

### DIFF
--- a/dockers/docker-orchagent/enable_counters.py
+++ b/dockers/docker-orchagent/enable_counters.py
@@ -4,9 +4,12 @@ import swsssdk
 import time
 
 def enable_counter_group(db, name):
-    info = {}
-    info['FLEX_COUNTER_STATUS'] = 'enable'
-    db.mod_entry("FLEX_COUNTER_TABLE", name, info)
+    entry_info = db.get_entry("FLEX_COUNTER_TABLE", name)
+
+    if not entry_info:
+        info = {}
+        info['FLEX_COUNTER_STATUS'] = 'enable'
+        db.mod_entry("FLEX_COUNTER_TABLE", name, info)
 
 def enable_counters():
     db = swsssdk.ConfigDBConnector()


### PR DESCRIPTION
Signed-off-by: Andriy Yurkiv <ayurkiv@nvidia.com>

Appropriate PR on master: https://github.com/Azure/sonic-buildimage/pull/7735
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
after "config reload" or "docker swss restart" all counterpoll counters were enabled even if they were disabled before
(merged from master)

#### How I did it
check if entry already exist before set default values

#### How to verify it
1) disable few counters
```
counterpoll pg-drop disable
counterpoll port disable
```
2) Save and reload
```
config save
config reload
```
3) Check enable status

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

