### PR TITLE
[Dual-ToR] update sai.profile for using additional MAC in FDB table (for routing purpose) to workaround MAC number limitation on SCP-1

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/ACS-MSN2700/sai.profile
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/ACS-MSN2700/sai.profile
@@ -1,3 +1,4 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/sai_2700.xml
 SAI_DUMP_STORE_PATH=/var/log/mellanox/sdk-dumps
 SAI_DUMP_STORE_AMOUNT=10
+SAI_ADDITIONAL_MAC_ENABLED=1

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/sai.profile
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/sai.profile
@@ -1,3 +1,4 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/sai_2700_48x50g_8x100g.xml
 SAI_DUMP_STORE_PATH=/var/log/mellanox/sdk-dumps
 SAI_DUMP_STORE_AMOUNT=10
+SAI_ADDITIONAL_MAC_ENABLED=1


### PR DESCRIPTION
Signed-off-by: Andriy Yurkiv <ayurkiv@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Need to add additional MAC to VLAN interface on SPC-1. It is impossible on SPC-1, so we just add a workaround: add this additional MAC  to FDB table, so forwarding will work 

Need to add for:
**Mellanox-SN2700, SN2700-D48C8**

#### How I did it
Add appropriate SAI attribute to sai.profile to enable this feature

#### How to verify it
apply Dual-ToR configuration on SPC-1
`ansible-playbook -i inventory --limit sonic-switch-1 deploy_minigraph.yml -e dut_minigraph=sonic-switch-1.dualtor.xml -b -vvv`
No crashes expected

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

