### PR TITLE
[Mellanox] Support DSCP remapping in Dual-ToR topo for SN4700-O8V48, update buffers for t0

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O8V48/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O8V48/buffers_defaults_t0.j2
@@ -15,10 +15,10 @@
 #}
 {% set default_cable = '5m' %}
 {%- if ((SYSTEM_DEFAULTS is defined) and ('tunnel_qos_remap' in SYSTEM_DEFAULTS) and (SYSTEM_DEFAULTS['tunnel_qos_remap']['status'] == 'enabled')) -%}
-{% set ingress_lossless_pool_size =  '45907968' %}
-{% set ingress_lossless_pool_xoff  =  '7479296' %}
+{% set ingress_lossless_pool_size =  '48168960' %}
+{% set ingress_lossless_pool_xoff  =  '5218304' %}
 {% set egress_lossless_pool_size =  '60817392' %}
-{% set egress_lossy_pool_size =  '45907968' %}
+{% set egress_lossy_pool_size =  '48168960' %}
 {%- else -%}
 {% set ingress_lossless_pool_size =  '49946624' %}
 {% set ingress_lossless_pool_xoff  =  '4063232' %}

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O8V48/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O8V48/buffers_defaults_t0.j2
@@ -1,5 +1,5 @@
 {#
-    Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+    Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
     Apache-2.0
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,10 +14,17 @@
     limitations under the License.
 #}
 {% set default_cable = '5m' %}
+{%- if ((SYSTEM_DEFAULTS is defined) and ('tunnel_qos_remap' in SYSTEM_DEFAULTS) and (SYSTEM_DEFAULTS['tunnel_qos_remap']['status'] == 'enabled')) -%}
+{% set ingress_lossless_pool_size =  '45907968' %}
+{% set ingress_lossless_pool_xoff  =  '7479296' %}
+{% set egress_lossless_pool_size =  '60817392' %}
+{% set egress_lossy_pool_size =  '45907968' %}
+{%- else -%}
 {% set ingress_lossless_pool_size =  '49946624' %}
 {% set ingress_lossless_pool_xoff  =  '4063232' %}
 {% set egress_lossless_pool_size =  '60817392' %}
 {% set egress_lossy_pool_size =  '49946624' %}
+{%- endif -%}
 
 {% import 'buffers_defaults_objects.j2' as defs with context %}
 
@@ -29,8 +36,16 @@
 {{ defs.generate_profile_lists(port_names_active, port_names_inactive) }}
 {%- endmacro %}
 
+{%- macro generate_queue_buffers_with_extra_lossless_queues_with_inactive_ports(port_names_active, port_names_extra_queues, port_names_inactive) %}
+{{ defs.generate_queue_buffers_with_extra_lossless_queues(port_names_active, port_names_extra_queues, port_names_inactive) }}
+{%- endmacro %}
+
 {%- macro generate_queue_buffers_with_inactive_ports(port_names_active, port_names_inactive) %}
 {{ defs.generate_queue_buffers(port_names_active, port_names_inactive) }}
+{%- endmacro %}
+
+{%- macro generate_pg_profiles_with_extra_lossless_pgs_with_inactive_ports(port_names_active, port_names_extra_pgs, port_names_inactive) %}
+{{ defs.generate_pg_profiles_with_extra_lossless_pgs(port_names_active, port_names_extra_pgs, port_names_inactive) }}
 {%- endmacro %}
 
 {%- macro generate_pg_profiles_with_inactive_ports(port_names_active, port_names_inactive) %}

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O8V48/qos.json.j2
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O8V48/qos.json.j2
@@ -1,1 +1,1 @@
-../../x86_64-mlnx_msn2700-r0/ACS-MSN2700/qos.json.j2
+../../x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/qos.json.j2


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Need to provide support for SN4700-O8V48 for Dual-ToR.
DSCP remapping is a part of Dual-ToR feature, so need to update HWSKU files to align with requirements

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
- Use QoS config the same as used in 4600C platform that is already supports Dual-ToR
- update buffers for T0

#### How to verify it
Run DSCP remapping test for Dual-ToR

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

