### PR TITLE
[Mellanox][202311] Adding SKU Mellanox-SN4700-O32 and Mellanox-SN4700-V64

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O32/buffers.json.j2
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O32/buffers.json.j2
@@ -1,0 +1,15 @@
+{#
+    Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES.
+    Apache-2.0
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+#}
+{%- set default_topo = 't1' %}
+{%- include 'buffers_config.j2' %}

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O32/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O32/buffers_defaults_objects.j2
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/buffers_defaults_objects.j2

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O32/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O32/buffers_defaults_t0.j2
@@ -1,0 +1,36 @@
+{#
+    Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES.
+    Apache-2.0
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+#}
+{% set default_cable = '5m' %}
+{% set ingress_lossless_pool_size = '51806208' %}
+{% set ingress_lossless_pool_xoff  = '3407872' %}
+{% set egress_lossless_pool_size =  '60817392' %}
+{% set egress_lossy_pool_size =  '51806208' %}
+
+{% import 'buffers_defaults_objects.j2' as defs with context %}
+
+{%- macro generate_buffer_pool_and_profiles_with_inactive_ports(port_names_inactive) %}
+{{ defs.generate_buffer_pool_and_profiles_with_inactive_ports(port_names_inactive) }}
+{%- endmacro %}
+
+{%- macro generate_profile_lists_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_profile_lists(port_names_active, port_names_inactive) }}
+{%- endmacro %}
+
+{%- macro generate_queue_buffers_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_queue_buffers(port_names_active, port_names_inactive) }}
+{%- endmacro %}
+
+{%- macro generate_pg_profiles_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_pg_profiles(port_names_active, port_names_inactive) }}
+{%- endmacro %}

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O32/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O32/buffers_defaults_t1.j2
@@ -1,0 +1,37 @@
+{#
+    Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES.
+    Apache-2.0
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+#}
+{% set default_cable = '40m' %}
+{% set ingress_lossless_pool_size =  '45531136' %}
+{% set ingress_lossless_pool_xoff  =  '9682944' %}
+{% set egress_lossless_pool_size =  '60817392' %}
+{% set egress_lossy_pool_size =  '45531136' %}
+
+
+{% import 'buffers_defaults_objects.j2' as defs with context %}
+
+{%- macro generate_buffer_pool_and_profiles_with_inactive_ports(port_names_inactive) %}
+{{ defs.generate_buffer_pool_and_profiles_with_inactive_ports(port_names_inactive) }}
+{%- endmacro %}
+
+{%- macro generate_profile_lists_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_profile_lists(port_names_active, port_names_inactive) }}
+{%- endmacro %}
+
+{%- macro generate_queue_buffers_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_queue_buffers(port_names_active, port_names_inactive) }}
+{%- endmacro %}
+
+{%- macro generate_pg_profiles_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_pg_profiles(port_names_active, port_names_inactive) }}
+{%- endmacro %}

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O32/buffers_dynamic.json.j2
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O32/buffers_dynamic.json.j2
@@ -1,0 +1,16 @@
+{#
+    Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+    Apache-2.0
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+#}
+{%- set default_topo = 't1' %}
+{%- set dynamic_mode = 'true' %}
+{%- include 'buffers_config.j2' %}

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O32/hwsku.json
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O32/hwsku.json
@@ -1,0 +1,132 @@
+{
+    "interfaces": {
+        "Ethernet0": {
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "autoneg": "off"
+        },
+        "Ethernet8": {
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "autoneg": "off"
+        },
+        "Ethernet16": {
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "autoneg": "off"
+        },
+        "Ethernet24": {
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "autoneg": "off"
+        },
+        "Ethernet32": {
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "autoneg": "off"
+        },
+        "Ethernet40": {
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "autoneg": "off"
+        },
+        "Ethernet48": {
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "autoneg": "off"
+        },
+        "Ethernet56": {
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "autoneg": "off"
+        },
+        "Ethernet64": {
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "autoneg": "off"
+        },
+        "Ethernet72": {
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "autoneg": "off"
+        },
+        "Ethernet80": {
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "autoneg": "off"
+        },
+        "Ethernet88": {
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "autoneg": "off"
+        },
+        "Ethernet96": {
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "autoneg": "off"
+        },
+        "Ethernet104": {
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "autoneg": "off"
+        },
+        "Ethernet112": {
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "autoneg": "off"
+        },
+        "Ethernet120": {
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "autoneg": "off"
+        },
+        "Ethernet128": {
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "autoneg": "off"
+        },
+        "Ethernet136": {
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "autoneg": "off"
+        },
+        "Ethernet144": {
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "autoneg": "off"
+        },
+        "Ethernet152": {
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "autoneg": "off"
+        },
+        "Ethernet160": {
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "autoneg": "off"
+        },
+        "Ethernet168": {
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "autoneg": "off"
+        },
+        "Ethernet176": {
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "autoneg": "off"
+        },
+        "Ethernet184": {
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "autoneg": "off"
+        },
+        "Ethernet192": {
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "autoneg": "off"
+        },
+        "Ethernet200": {
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "autoneg": "off"
+        },
+        "Ethernet208": {
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "autoneg": "off"
+        },
+        "Ethernet216": {
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "autoneg": "off"
+        },
+        "Ethernet224": {
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "autoneg": "off"
+        },
+        "Ethernet232": {
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "autoneg": "off"
+        },
+        "Ethernet240": {
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "autoneg": "off"
+        },
+        "Ethernet248": {
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+            "autoneg": "off"
+        }
+    }
+}

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O32/media_settings.json
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O32/media_settings.json
@@ -1,0 +1,1 @@
+../Mellanox-SN4700-O8C48/media_settings.json

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O32/optics_si_settings.json
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O32/optics_si_settings.json
@@ -1,0 +1,1 @@
+../Mellanox-SN4700-O8C48/optics_si_settings.json

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O32/pg_profile_lookup.ini
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O32/pg_profile_lookup.ini
@@ -1,0 +1,1 @@
+../../x86_64-nvidia_sn4280-r0/ACS-SN4280/pg_profile_lookup.ini

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O32/pg_profile_lookup.ini
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O32/pg_profile_lookup.ini
@@ -1,1 +1,53 @@
-../../x86_64-nvidia_sn4280-r0/ACS-SN4280/pg_profile_lookup.ini
+##
+## Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+## Apache-2.0
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+#  PG lossless profiles.
+# speed cable  size   xon    xoff   threshold
+  10000    5m 19456  19456  16384          0
+  25000    5m 19456  19456  17408          0
+  40000    5m 19456  19456  19456          0
+  50000    5m 19456  19456  21504          0
+ 100000    5m 19456  19456  37888          0
+ 200000    5m 19456  19456  43008          0
+ 400000    5m 38912  38912  73728          0
+  10000   40m 19456  19456  16384          0
+  25000   40m 19456  19456  18432          0
+  40000   40m 19456  19456  21504          0
+  50000   40m 19456  19456  23552          0
+ 100000   40m 19456  19456  43008          0
+ 200000   40m 19456  19456  51200          0
+ 400000   40m 38912  38912  91136          0
+  10000  300m 19456  19456  19456          0
+  25000  300m 19456  19456  26624          0
+  40000  300m 19456  19456  34816          0
+  50000  300m 19456  19456  40960          0
+ 100000  300m 19456  19456  75776          0
+ 200000  300m 19456  19456  118784         0
+ 400000  300m 38912  38912  225280         0
+  10000 1500m 19456  19456  35840          0
+  25000 1500m 19456  19456  65536          0
+  40000 1500m 19456  19456  96256          0
+  50000 1500m 19456  19456  117760         0
+ 100000 1500m 19456  19456  230400         0
+ 200000 1500m 19456  19456  427008         0
+ 400000 1500m 38912  38912  427008         0
+  10000 2000m 19456  19456  41984          0
+  25000 2000m 19456  19456  80896          0
+  40000 2000m 19456  19456  121856         0
+  50000 2000m 19456  19456  149504         0
+ 100000 2000m 19456  19456  293888         0
+ 200000 2000m 19456  19456  555008         0
+ 400000 2000m 38912  38912  555008         0

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O32/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O32/pmon_daemon_control.json
@@ -1,0 +1,6 @@
+{
+    "skip_ledd": true,
+    "skip_fancontrol": true,
+    "skip_xcvrd_cmis_mgr": false
+}
+

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O32/port_config.ini
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O32/port_config.ini
@@ -1,0 +1,1 @@
+../ACS-MSN4700/port_config.ini

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O32/qos.json.j2
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O32/qos.json.j2
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/ACS-MSN2700/qos.json.j2

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O32/sai.profile
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O32/sai.profile
@@ -1,0 +1,2 @@
+SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/sai_4700_32x400g.xml
+SAI_INDEPENDENT_MODULE_MODE=1

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O32/sai_4700_32x400g.xml
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O32/sai_4700_32x400g.xml
@@ -1,0 +1,297 @@
+<!--
+  Copyright (c) 2019-2024 NVIDIA CORPORATION & AFFILIATES.
+  Apache-2.0
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<root>
+    <platform_info type="4700">
+
+        <!-- Device MAC address  -->
+        <device-mac-address>00:02:03:04:05:00</device-mac-address>
+
+        <!-- ISSU enabled -->
+        <issu-enabled>1</issu-enabled>
+
+        <!-- Number of ports in the following port list -->
+        <number-of-physical-ports>32</number-of-physical-ports>
+
+        <!-- Global port late create -->
+        <late-create-all-ports>1</late-create-all-ports>
+
+        <!-- List of ports in the device -->
+        <ports-list>
+            <port-info>
+                <local-port>1</local-port>
+                <width>8</width>
+                <module>17</module>
+
+                <!-- 0 none, 1=2, 2=4, 3=2,4 -->
+                <breakout-modes>0</breakout-modes>
+
+                <!-- (BITMASK) 2 - 1Gb , 16 - 10Gb , 32 - 40Gb , 384 - 50Gb , 1536 - 100Gb , 4096 - 200Gb, 32768 - 400G, 262144 - 800G -->-->
+                <port-speed>32768</port-speed>
+                <split>1</split>
+            </port-info>
+            <port-info>
+                <local-port>5</local-port>
+                <width>8</width>
+                <module>16</module>
+                <breakout-modes>0</breakout-modes>
+                <port-speed>32768</port-speed>
+                <split>1</split>
+            </port-info>
+            <port-info>
+                <local-port>9</local-port>
+                <width>8</width>
+                <module>19</module>
+                <breakout-modes>0</breakout-modes>
+                <port-speed>32768</port-speed>
+                <split>1</split>
+            </port-info>
+            <port-info>
+                <local-port>13</local-port>
+                <width>8</width>
+                <module>18</module>
+                <breakout-modes>0</breakout-modes>
+                <port-speed>32768</port-speed>
+                <split>1</split>
+            </port-info>
+            <port-info>
+                <local-port>17</local-port>
+                <width>8</width>
+                <module>21</module>
+                <breakout-modes>0</breakout-modes>
+                <port-speed>32768</port-speed>
+                <split>1</split>
+            </port-info>
+            <port-info>
+                <local-port>21</local-port>
+                <width>8</width>
+                <module>20</module>
+                <breakout-modes>0</breakout-modes>
+                <port-speed>32768</port-speed>
+                <split>1</split>
+            </port-info>
+            <port-info>
+                <local-port>25</local-port>
+                <width>8</width>
+                <module>23</module>
+                <breakout-modes>1</breakout-modes>
+                <port-speed>32768</port-speed>
+                <split>1</split>
+            </port-info>
+            <port-info>
+                <local-port>29</local-port>
+                <width>8</width>
+                <module>22</module>
+                <breakout-modes>0</breakout-modes>
+                <port-speed>32768</port-speed>
+                <split>1</split>
+            </port-info>
+            <port-info>
+                <local-port>33</local-port>
+                <width>8</width>
+                <module>29</module>
+                <breakout-modes>0</breakout-modes>
+                <port-speed>32768</port-speed>
+                <split>1</split>
+            </port-info>
+            <port-info>
+                <local-port>37</local-port>
+                <width>8</width>
+                <module>28</module>
+                <breakout-modes>0</breakout-modes>
+                <port-speed>32768</port-speed>
+                <split>1</split>
+            </port-info>
+            <port-info>
+                <local-port>41</local-port>
+                <width>8</width>
+                <module>31</module>
+                <breakout-modes>0</breakout-modes>
+                <port-speed>32768</port-speed>
+                <split>1</split>
+            </port-info>
+            <port-info>
+                <local-port>45</local-port>
+                <width>8</width>
+                <module>30</module>
+                <breakout-modes>0</breakout-modes>
+                <port-speed>32768</port-speed>
+                <split>1</split>
+            </port-info>
+            <port-info>
+                <local-port>49</local-port>
+                <width>8</width>
+                <module>25</module>
+                <breakout-modes>0</breakout-modes>
+                <port-speed>32768</port-speed>
+                <split>1</split>
+            </port-info>
+            <port-info>
+                <local-port>53</local-port>
+                <width>8</width>
+                <module>24</module>
+                <breakout-modes>0</breakout-modes>
+                <port-speed>32768</port-speed>
+                <split>1</split>
+            </port-info>
+            <port-info>
+                <local-port>57</local-port>
+                <width>8</width>
+                <module>27</module>
+                <breakout-modes>0</breakout-modes>
+                <port-speed>32768</port-speed>
+                <split>1</split>
+            </port-info>
+            <port-info>
+                <local-port>61</local-port>
+                <width>8</width>
+                <module>26</module>
+                <breakout-modes>0</breakout-modes>
+                <port-speed>32768</port-speed>
+                <split>1</split>
+            </port-info>
+            <port-info>
+                <local-port>65</local-port>
+                <width>8</width>
+                <module>14</module>
+                <breakout-modes>0</breakout-modes>
+                <port-speed>32768</port-speed>
+                <split>1</split>
+            </port-info>
+            <port-info>
+                <local-port>69</local-port>
+                <width>8</width>
+                <module>15</module>
+                <breakout-modes>0</breakout-modes>
+                <port-speed>32768</port-speed>
+                <split>1</split>
+            </port-info>
+            <port-info>
+                <local-port>73</local-port>
+                <width>8</width>
+                <module>12</module>
+                <breakout-modes>0</breakout-modes>
+                <port-speed>32768</port-speed>
+                <split>1</split>
+            </port-info>
+            <port-info>
+                <local-port>77</local-port>
+                <width>8</width>
+                <module>13</module>
+                <breakout-modes>0</breakout-modes>
+                <port-speed>32768</port-speed>
+                <split>1</split>
+            </port-info>
+            <port-info>
+                <local-port>81</local-port>
+                <width>8</width>
+                <module>10</module>
+                <breakout-modes>0</breakout-modes>
+                <port-speed>32768</port-speed>
+                <split>1</split>
+            </port-info>
+            <port-info>
+                <local-port>85</local-port>
+                <width>8</width>
+                <module>11</module>
+                <breakout-modes>0</breakout-modes>
+                <port-speed>32768</port-speed>
+                <split>1</split>
+            </port-info>
+            <port-info>
+                <local-port>89</local-port>
+                <width>8</width>
+                <module>8</module>
+                <breakout-modes>0</breakout-modes>
+                <port-speed>32768</port-speed>
+                <split>1</split>
+            </port-info>
+            <port-info>
+                <local-port>93</local-port>
+                <width>8</width>
+                <module>9</module>
+                <breakout-modes>0</breakout-modes>
+                <port-speed>32768</port-speed>
+                <split>1</split>
+            </port-info>
+            <port-info>
+                <local-port>97</local-port>
+                <width>8</width>
+                <module>2</module>
+                <breakout-modes>0</breakout-modes>
+                <port-speed>32768</port-speed>
+                <split>1</split>
+            </port-info>
+            <port-info>
+                <local-port>101</local-port>
+                <width>8</width>
+                <module>3</module>
+                <breakout-modes>0</breakout-modes>
+                <port-speed>32768</port-speed>
+                <split>1</split>
+            </port-info>
+            <port-info>
+                <local-port>105</local-port>
+                <width>8</width>
+                <module>0</module>
+                <breakout-modes>0</breakout-modes>
+                <port-speed>32768</port-speed>
+                <split>1</split>
+            </port-info>
+            <port-info>
+                <local-port>109</local-port>
+                <width>8</width>
+                <module>1</module>
+                <breakout-modes>0</breakout-modes>
+                <port-speed>32768</port-speed>
+                <split>1</split>
+            </port-info>
+            <port-info>
+                <local-port>113</local-port>
+                <width>8</width>
+                <module>6</module>
+                <breakout-modes>0</breakout-modes>
+                <port-speed>32768</port-speed>
+                <split>1</split>
+            </port-info>
+            <port-info>
+                <local-port>117</local-port>
+                <width>8</width>
+                <module>7</module>
+                <breakout-modes>0</breakout-modes>
+                <port-speed>32768</port-speed>
+                <split>1</split>
+            </port-info>
+            <port-info>
+                <local-port>121</local-port>
+                <width>8</width>
+                <module>4</module>
+                <breakout-modes>0</breakout-modes>
+                <port-speed>32768</port-speed>
+                <split>1</split>
+            </port-info>
+            <port-info>
+                <local-port>125</local-port>
+                <width>8</width>
+                <module>5</module>
+                <breakout-modes>0</breakout-modes>
+                <port-speed>32768</port-speed>
+                <split>1</split>
+            </port-info>
+        </ports-list>
+    </platform_info>
+</root>

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-V64/buffers.json.j2
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-V64/buffers.json.j2
@@ -1,0 +1,15 @@
+{#
+    Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+    Apache-2.0
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+#}
+{%- set default_topo = 't0' %}
+{%- include 'buffers_config.j2' %}

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-V64/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-V64/buffers_defaults_objects.j2
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/buffers_defaults_objects.j2

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-V64/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-V64/buffers_defaults_t0.j2
@@ -1,0 +1,53 @@
+{#
+    Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+    Apache-2.0
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+#}
+{% set default_cable = '5m' %}
+{%- if ((SYSTEM_DEFAULTS is defined) and ('tunnel_qos_remap' in SYSTEM_DEFAULTS) and (SYSTEM_DEFAULTS['tunnel_qos_remap']['status'] == 'enabled')) -%}
+{% set ingress_lossless_pool_size =  '47448064' %}
+{% set ingress_lossless_pool_xoff  =  '5537792' %}
+{% set egress_lossless_pool_size =  '60817392' %}
+{% set egress_lossy_pool_size =  '47448064' %}
+{%- else -%}
+{% set ingress_lossless_pool_size =  '49971200' %}
+{% set ingress_lossless_pool_xoff  =  '3637248' %}
+{% set egress_lossless_pool_size =  '60817392' %}
+{% set egress_lossy_pool_size =  '49971200' %}
+{%- endif -%}
+
+{% import 'buffers_defaults_objects.j2' as defs with context %}
+
+{%- macro generate_buffer_pool_and_profiles_with_inactive_ports(port_names_inactive) %}
+{{ defs.generate_buffer_pool_and_profiles_with_inactive_ports(port_names_inactive) }}
+{%- endmacro %}
+
+{%- macro generate_profile_lists_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_profile_lists(port_names_active, port_names_inactive) }}
+{%- endmacro %}
+
+{%- macro generate_queue_buffers_with_extra_lossless_queues_with_inactive_ports(port_names_active, port_names_extra_queues, port_names_inactive) %}
+{{ defs.generate_queue_buffers_with_extra_lossless_queues(port_names_active, port_names_extra_queues, port_names_inactive) }}
+{%- endmacro %}
+
+{%- macro generate_queue_buffers_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_queue_buffers(port_names_active, port_names_inactive) }}
+{%- endmacro %}
+
+{%- macro generate_pg_profiles_with_extra_lossless_pgs_with_inactive_ports(port_names_active, port_names_extra_pgs, port_names_inactive) %}
+{{ defs.generate_pg_profiles_with_extra_lossless_pgs(port_names_active, port_names_extra_pgs, port_names_inactive) }}
+{%- endmacro %}
+
+{%- macro generate_pg_profiles_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_pg_profiles(port_names_active, port_names_inactive) }}
+{%- endmacro %}

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-V64/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-V64/buffers_defaults_t1.j2
@@ -1,0 +1,56 @@
+{#
+    Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+    Apache-2.0
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+#}
+
+{% set default_cable = '40m' %}
+{%- if ((SYSTEM_DEFAULTS is defined) and ('tunnel_qos_remap' in SYSTEM_DEFAULTS) and (SYSTEM_DEFAULTS['tunnel_qos_remap']['status'] == 'enabled')) -%}
+{% set ingress_lossless_pool_size =  '31784960' %}
+{% set ingress_lossless_pool_xoff  =  '19955712' %}
+{% set egress_lossless_pool_size =  '60817392' %}
+{% set egress_lossy_pool_size =  '31784960' %}
+{%- else -%}
+{% set ingress_lossless_pool_size =  '39354368' %}
+{% set ingress_lossless_pool_xoff  =  '14254080' %}
+{% set egress_lossless_pool_size =  '60817392' %}
+{% set egress_lossy_pool_size =  '39354368' %}
+{%- endif -%}
+
+
+
+{% import 'buffers_defaults_objects.j2' as defs with context %}
+
+{%- macro generate_buffer_pool_and_profiles_with_inactive_ports(port_names_inactive) %}
+{{ defs.generate_buffer_pool_and_profiles_with_inactive_ports(port_names_inactive) }}
+{%- endmacro %}
+
+{%- macro generate_profile_lists_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_profile_lists(port_names_active, port_names_inactive) }}
+{%- endmacro %}
+
+{%- macro generate_queue_buffers_with_extra_lossless_queues_with_inactive_ports(port_names_active, port_names_extra_queues, port_names_inactive) %}
+{{ defs.generate_queue_buffers_with_extra_lossless_queues(port_names_active, port_names_extra_queues, port_names_inactive) }}
+{%- endmacro %}
+
+{%- macro generate_queue_buffers_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_queue_buffers(port_names_active, port_names_inactive) }}
+{%- endmacro %}
+
+{%- macro generate_pg_profiles_with_extra_lossless_pgs_with_inactive_ports(port_names_active, port_names_extra_pgs, port_names_inactive) %}
+{{ defs.generate_pg_profiles_with_extra_lossless_pgs(port_names_active, port_names_extra_pgs, port_names_inactive) }}
+{%- endmacro %}
+
+{%- macro generate_pg_profiles_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_pg_profiles(port_names_active, port_names_inactive) }}
+{%- endmacro %}

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-V64/buffers_dynamic.json.j2
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-V64/buffers_dynamic.json.j2
@@ -1,0 +1,18 @@
+{#
+    Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+    Apache-2.0
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+#}
+{%- set default_topo = 't0' %}
+{%- set dynamic_mode = 'true' %}
+{%- include 'buffers_config.j2' %}

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-V64/hwsku.json
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-V64/hwsku.json
@@ -1,0 +1,324 @@
+{
+    "interfaces": {
+        "Ethernet0": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet4": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet8": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet12": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet16": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet20": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet24": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet28": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet32": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet36": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet40": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet44": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet48": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet52": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet56": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet60": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet64": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet68": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet72": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet76": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet80": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet84": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet88": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet92": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet96": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet100": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet104": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet108": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet112": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet116": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet120": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet124": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet128": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet132": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet136": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet140": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet144": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet148": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet152": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet156": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet160": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet164": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet168": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet172": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet176": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet180": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet184": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet188": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet192": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet196": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet200": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet204": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet208": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet212": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet216": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet220": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet224": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet228": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet232": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet236": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet240": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet244": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        },
+        "Ethernet248": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "1",
+            "autoneg": "off"
+        },
+        "Ethernet252": {
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
+            "subport": "2",
+            "autoneg": "off"
+        }
+    }
+}

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-V64/media_settings.json
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-V64/media_settings.json
@@ -1,0 +1,1 @@
+../Mellanox-SN4700-O8C48/media_settings.json

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-V64/optics_si_settings.json
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-V64/optics_si_settings.json
@@ -1,0 +1,1 @@
+../Mellanox-SN4700-O8C48/optics_si_settings.json

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-V64/pg_profile_lookup.ini
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-V64/pg_profile_lookup.ini
@@ -1,0 +1,1 @@
+../../x86_64-nvidia_sn4280-r0/ACS-SN4280/pg_profile_lookup.ini

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-V64/pg_profile_lookup.ini
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-V64/pg_profile_lookup.ini
@@ -1,1 +1,53 @@
-../../x86_64-nvidia_sn4280-r0/ACS-SN4280/pg_profile_lookup.ini
+##
+## Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+## Apache-2.0
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+#  PG lossless profiles.
+# speed cable  size   xon    xoff   threshold
+  10000    5m 19456  19456  16384          0
+  25000    5m 19456  19456  17408          0
+  40000    5m 19456  19456  19456          0
+  50000    5m 19456  19456  21504          0
+ 100000    5m 19456  19456  37888          0
+ 200000    5m 19456  19456  43008          0
+ 400000    5m 38912  38912  73728          0
+  10000   40m 19456  19456  16384          0
+  25000   40m 19456  19456  18432          0
+  40000   40m 19456  19456  21504          0
+  50000   40m 19456  19456  23552          0
+ 100000   40m 19456  19456  43008          0
+ 200000   40m 19456  19456  51200          0
+ 400000   40m 38912  38912  91136          0
+  10000  300m 19456  19456  19456          0
+  25000  300m 19456  19456  26624          0
+  40000  300m 19456  19456  34816          0
+  50000  300m 19456  19456  40960          0
+ 100000  300m 19456  19456  75776          0
+ 200000  300m 19456  19456  118784         0
+ 400000  300m 38912  38912  225280         0
+  10000 1500m 19456  19456  35840          0
+  25000 1500m 19456  19456  65536          0
+  40000 1500m 19456  19456  96256          0
+  50000 1500m 19456  19456  117760         0
+ 100000 1500m 19456  19456  230400         0
+ 200000 1500m 19456  19456  427008         0
+ 400000 1500m 38912  38912  427008         0
+  10000 2000m 19456  19456  41984          0
+  25000 2000m 19456  19456  80896          0
+  40000 2000m 19456  19456  121856         0
+  50000 2000m 19456  19456  149504         0
+ 100000 2000m 19456  19456  293888         0
+ 200000 2000m 19456  19456  555008         0
+ 400000 2000m 38912  38912  555008         0

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-V64/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-V64/pmon_daemon_control.json
@@ -1,0 +1,6 @@
+{
+    "skip_ledd": true,
+    "skip_fancontrol": true,
+    "skip_xcvrd_cmis_mgr": false
+}
+

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-V64/port_config.ini
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-V64/port_config.ini
@@ -1,0 +1,81 @@
+##
+## Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+## Apache-2.0
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+# name          lanes             alias     index    speed
+Ethernet0      0,1,2,3            etp1a     1        200000
+Ethernet4      4,5,6,7            etp1b     1        200000
+Ethernet8      8,9,10,11          etp2a     2        200000
+Ethernet12     12,13,14,15        etp2b     2        200000
+Ethernet16     16,17,18,19        etp3a     3        200000
+Ethernet20     20,21,22,23        etp3b     3        200000
+Ethernet24     24,25,26,27        etp4a     4        200000
+Ethernet28     28,29,30,31        etp4b     4        200000
+Ethernet32     32,33,34,35        etp5a     5        200000
+Ethernet36     36,37,38,39        etp5b     5        200000
+Ethernet40     40,41,42,43        etp6a     6        200000
+Ethernet44     44,45,46,47        etp6b     6        200000
+Ethernet48     48,49,50,51        etp7a     7        200000
+Ethernet52     52,53,54,55        etp7b     7        200000
+Ethernet56     56,57,58,59        etp8a     8        200000
+Ethernet60     60,61,62,63        etp8b     8        200000
+Ethernet64     64,65,66,67        etp9a     9        200000
+Ethernet68     68,69,70,71        etp9b     9        200000
+Ethernet72     72,73,74,75        etp10a    10       200000
+Ethernet76     76,77,78,79        etp10b    10       200000
+Ethernet80     80,81,82,83        etp11a    11       200000
+Ethernet84     84,85,86,87        etp11b    11       200000
+Ethernet88     88,89,90,91        etp12a    12       200000
+Ethernet92     92,93,94,95        etp12b    12       200000
+Ethernet96     96,97,98,99        etp13a    13       200000
+Ethernet100    100,101,102,103    etp13b    13       200000
+Ethernet104    104,105,106,107    etp14a    14       200000
+Ethernet108    108,109,110,111    etp14b    14       200000
+Ethernet112    112,113,114,115    etp15a    15       200000
+Ethernet116    116,117,118,119    etp15b    15       200000
+Ethernet120    120,121,122,123    etp16a    16       200000
+Ethernet124    124,125,126,127    etp16b    16       200000
+Ethernet128    128,129,130,131    etp17a    17       200000
+Ethernet132    132,133,134,135    etp17b    17       200000
+Ethernet136    136,137,138,139    etp18a    18       200000
+Ethernet140    140,141,142,143    etp18b    18       200000
+Ethernet144    144,145,146,147    etp19a    19       200000
+Ethernet148    148,149,150,151    etp19b    19       200000
+Ethernet152    152,153,154,155    etp20a    20       200000
+Ethernet156    156,157,158,159    etp20b    20       200000
+Ethernet160    160,161,162,163    etp21a    21       200000
+Ethernet164    164,165,166,167    etp21b    21       200000
+Ethernet168    168,169,170,171    etp22a    22       200000
+Ethernet172    172,173,174,175    etp22b    22       200000
+Ethernet176    176,177,178,179    etp23a    23       200000
+Ethernet180    180,181,182,183    etp23b    23       200000
+Ethernet184    184,185,186,187    etp24a    24       200000
+Ethernet188    188,189,190,191    etp24b    24       200000
+Ethernet192    192,193,194,195    etp25a    25       200000
+Ethernet196    196,197,198,199    etp25b    25       200000
+Ethernet200    200,201,202,203    etp26a    26       200000
+Ethernet204    204,205,206,207    etp26b    26       200000
+Ethernet208    208,209,210,211    etp27a    27       200000
+Ethernet212    212,213,214,215    etp27b    27       200000
+Ethernet216    216,217,218,219    etp28a    28       200000
+Ethernet220    220,221,222,223    etp28b    28       200000
+Ethernet224    224,225,226,227    etp29a    29       200000
+Ethernet228    228,229,230,231    etp29b    29       200000
+Ethernet232    232,233,234,235    etp30a    30       200000
+Ethernet236    236,237,238,239    etp30b    30       200000
+Ethernet240    240,241,242,243    etp31a    31       200000
+Ethernet244    244,245,246,247    etp31b    31       200000
+Ethernet248    248,249,250,251    etp32a    32       200000
+Ethernet252    252,253,254,255    etp32b    32       200000

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-V64/qos.json.j2
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-V64/qos.json.j2
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/qos.json.j2

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-V64/sai.profile
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-V64/sai.profile
@@ -1,0 +1,2 @@
+SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/sai_4700_64x200g.xml
+SAI_INDEPENDENT_MODULE_MODE=1

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-V64/sai_4700_64x200g.xml
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-V64/sai_4700_64x200g.xml
@@ -1,0 +1,297 @@
+<!--
+  Copyright (c) 2019-2024 NVIDIA CORPORATION & AFFILIATES.
+  Apache-2.0
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<root>
+    <platform_info type="4700">
+
+        <!-- Device MAC address  -->
+        <device-mac-address>00:02:03:04:05:00</device-mac-address>
+
+        <!-- ISSU enabled -->
+        <issu-enabled>1</issu-enabled>
+
+        <!-- Number of ports in the following port list -->
+        <number-of-physical-ports>32</number-of-physical-ports>
+
+        <!-- Global port late create -->
+        <late-create-all-ports>1</late-create-all-ports>
+
+        <!-- List of ports in the device -->
+        <ports-list>
+            <port-info>
+                <local-port>1</local-port>
+                <width>8</width>
+                <module>17</module>
+
+                <!-- 0 none, 1=2, 2=4, 3=2,4 -->
+                <breakout-modes>1</breakout-modes>
+
+                <!-- (BITMASK) 2 - 1Gb , 16 - 10Gb , 32 - 40Gb , 384 - 50Gb , 1536 - 100Gb , 4096 - 200Gb, 32768 - 400G, 262144 - 800G -->-->
+                <port-speed>4096</port-speed>
+                <split>2</split>
+            </port-info>
+            <port-info>
+                <local-port>5</local-port>
+                <width>8</width>
+                <module>16</module>
+                <breakout-modes>1</breakout-modes>
+                <port-speed>4096</port-speed>
+                <split>2</split>
+            </port-info>
+            <port-info>
+                <local-port>9</local-port>
+                <width>8</width>
+                <module>19</module>
+                <breakout-modes>1</breakout-modes>
+                <port-speed>4096</port-speed>
+                <split>2</split>
+            </port-info>
+            <port-info>
+                <local-port>13</local-port>
+                <width>8</width>
+                <module>18</module>
+                <breakout-modes>1</breakout-modes>
+                <port-speed>4096</port-speed>
+                <split>2</split>
+            </port-info>
+            <port-info>
+                <local-port>17</local-port>
+                <width>8</width>
+                <module>21</module>
+                <breakout-modes>1</breakout-modes>
+                <port-speed>4096</port-speed>
+                <split>2</split>
+            </port-info>
+            <port-info>
+                <local-port>21</local-port>
+                <width>8</width>
+                <module>20</module>
+                <breakout-modes>1</breakout-modes>
+                <port-speed>4096</port-speed>
+                <split>2</split>
+            </port-info>
+            <port-info>
+                <local-port>25</local-port>
+                <width>8</width>
+                <module>23</module>
+                <breakout-modes>1</breakout-modes>
+                <port-speed>4096</port-speed>
+                <split>2</split>
+            </port-info>
+            <port-info>
+                <local-port>29</local-port>
+                <width>8</width>
+                <module>22</module>
+                <breakout-modes>1</breakout-modes>
+                <port-speed>4096</port-speed>
+                <split>2</split>
+            </port-info>
+            <port-info>
+                <local-port>33</local-port>
+                <width>8</width>
+                <module>29</module>
+                <breakout-modes>1</breakout-modes>
+                <port-speed>4096</port-speed>
+                <split>2</split>
+            </port-info>
+            <port-info>
+                <local-port>37</local-port>
+                <width>8</width>
+                <module>28</module>
+                <breakout-modes>1</breakout-modes>
+                <port-speed>4096</port-speed>
+                <split>2</split>
+            </port-info>
+            <port-info>
+                <local-port>41</local-port>
+                <width>8</width>
+                <module>31</module>
+                <breakout-modes>1</breakout-modes>
+                <port-speed>4096</port-speed>
+                <split>2</split>
+            </port-info>
+            <port-info>
+                <local-port>45</local-port>
+                <width>8</width>
+                <module>30</module>
+                <breakout-modes>1</breakout-modes>
+                <port-speed>4096</port-speed>
+                <split>2</split>
+            </port-info>
+            <port-info>
+                <local-port>49</local-port>
+                <width>8</width>
+                <module>25</module>
+                <breakout-modes>1</breakout-modes>
+                <port-speed>4096</port-speed>
+                <split>2</split>
+            </port-info>
+            <port-info>
+                <local-port>53</local-port>
+                <width>8</width>
+                <module>24</module>
+                <breakout-modes>1</breakout-modes>
+                <port-speed>4096</port-speed>
+                <split>2</split>
+            </port-info>
+            <port-info>
+                <local-port>57</local-port>
+                <width>8</width>
+                <module>27</module>
+                <breakout-modes>1</breakout-modes>
+                <port-speed>4096</port-speed>
+                <split>2</split>
+            </port-info>
+            <port-info>
+                <local-port>61</local-port>
+                <width>8</width>
+                <module>26</module>
+                <breakout-modes>1</breakout-modes>
+                <port-speed>4096</port-speed>
+                <split>2</split>
+            </port-info>
+            <port-info>
+                <local-port>65</local-port>
+                <width>8</width>
+                <module>14</module>
+                <breakout-modes>1</breakout-modes>
+                <port-speed>4096</port-speed>
+                <split>1</split>
+            </port-info>
+            <port-info>
+                <local-port>69</local-port>
+                <width>8</width>
+                <module>15</module>
+                <breakout-modes>1</breakout-modes>
+                <port-speed>4096</port-speed>
+                <split>1</split>
+            </port-info>
+            <port-info>
+                <local-port>73</local-port>
+                <width>8</width>
+                <module>12</module>
+                <breakout-modes>1</breakout-modes>
+                <port-speed>4096</port-speed>
+                <split>1</split>
+            </port-info>
+            <port-info>
+                <local-port>77</local-port>
+                <width>8</width>
+                <module>13</module>
+                <breakout-modes>1</breakout-modes>
+                <port-speed>4096</port-speed>
+                <split>1</split>
+            </port-info>
+            <port-info>
+                <local-port>81</local-port>
+                <width>8</width>
+                <module>10</module>
+                <breakout-modes>1</breakout-modes>
+                <port-speed>4096</port-speed>
+                <split>2</split>
+            </port-info>
+            <port-info>
+                <local-port>85</local-port>
+                <width>8</width>
+                <module>11</module>
+                <breakout-modes>1</breakout-modes>
+                <port-speed>4096</port-speed>
+                <split>2</split>
+            </port-info>
+            <port-info>
+                <local-port>89</local-port>
+                <width>8</width>
+                <module>8</module>
+                <breakout-modes>1</breakout-modes>
+                <port-speed>4096</port-speed>
+                <split>2</split>
+            </port-info>
+            <port-info>
+                <local-port>93</local-port>
+                <width>8</width>
+                <module>9</module>
+                <breakout-modes>1</breakout-modes>
+                <port-speed>4096</port-speed>
+                <split>2</split>
+            </port-info>
+            <port-info>
+                <local-port>97</local-port>
+                <width>8</width>
+                <module>2</module>
+                <breakout-modes>1</breakout-modes>
+                <port-speed>4096</port-speed>
+                <split>2</split>
+            </port-info>
+            <port-info>
+                <local-port>101</local-port>
+                <width>8</width>
+                <module>3</module>
+                <breakout-modes>1</breakout-modes>
+                <port-speed>4096</port-speed>
+                <split>2</split>
+            </port-info>
+            <port-info>
+                <local-port>105</local-port>
+                <width>8</width>
+                <module>0</module>
+                <breakout-modes>1</breakout-modes>
+                <port-speed>4096</port-speed>
+                <split>2</split>
+            </port-info>
+            <port-info>
+                <local-port>109</local-port>
+                <width>8</width>
+                <module>1</module>
+                <breakout-modes>1</breakout-modes>
+                <port-speed>4096</port-speed>
+                <split>2</split>
+            </port-info>
+            <port-info>
+                <local-port>113</local-port>
+                <width>8</width>
+                <module>6</module>
+                <breakout-modes>1</breakout-modes>
+                <port-speed>4096</port-speed>
+                <split>2</split>
+            </port-info>
+            <port-info>
+                <local-port>117</local-port>
+                <width>8</width>
+                <module>7</module>
+                <breakout-modes>1</breakout-modes>
+                <port-speed>4096</port-speed>
+                <split>2</split>
+            </port-info>
+            <port-info>
+                <local-port>121</local-port>
+                <width>8</width>
+                <module>4</module>
+                <breakout-modes>1</breakout-modes>
+                <port-speed>4096</port-speed>
+                <split>2</split>
+            </port-info>
+            <port-info>
+                <local-port>125</local-port>
+                <width>8</width>
+                <module>5</module>
+                <breakout-modes>1</breakout-modes>
+                <port-speed>4096</port-speed>
+                <split>2</split>
+            </port-info>
+        </ports-list>
+    </platform_info>
+</root>


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

**Additional changes for 202311**
- On master branch, **pg_profile_lookup.ini** was pointed to **pg_profile_lookup.ini**  from SN4280 as a symlink
But SN4280 wasn't merged to 202311
Need to use files instead of links

#### Why I did it
A new SKUs for MSN4700 Platform: **Mellanox-SN4700-O32** and **Mellanox-SN4700-V64**

Requirements for Mellanox-SN4700-O32:
- 8 x 400Gbps uplink to T2 switch (O13 to O20)
- 24 x 400Gbps downlinks to T0 switch (O1-O12, O21-O32)
- Breakout mode No breakout mode. All ports working in 400Gb mode. .
- FEC mode: RS
- Type of transceiver: 400Gb Optical.
- warm boot should be supported “No for T1 role”
- VxLAN source port range set N/A
- Static Policy Based Hashing supported N/A
- Cable length “T0-T1 40m default, 300m max; T1-T2 2000m”
- Tradition buffer model is must “Yes”
- Shared headroom should be supported “Yes”
- Over-subscription ratio: “2”.

Requirements for **Mellanox-SN4700-V64**

- 16 x 200Gbps uplink to T1 switch (V-25&V26 to V-39&40)
- 48 x 200Gbps downlinks to servers (Left panel downlink ports: V-1&2 to V-23&24; Right panel downlink ports: V-41&42 to V-63&64)
- Breakout mode split from 400Gbps ports (2x200)
- FEC mode: RS
- Type of transceiver: 200Gb AOC between T0 and T1; 200Gb DAC between T0 and host.
- warm boot should be supported “Yes for T0 role”
- VxLAN source port range set N/A
- Static Policy Based Hashing supported N/A
- Cable length “T0-T1 40m default, 300m max, T0-Server 5m”
- Tradition buffer model is must “Yes”
- Shared headroom should be supported “Yes”
- Over-subscription ratio: “2”.

Additional Details:

QoS configs for Mellanox-SN4700-V64 updated in order to fulfill Dual-ToR buffer (+DSCP remapping) requirements
Support for independent module added for both SKUs, so Auto-negotiation changed to NO


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Unlink pg_profile_lookup.ini and copy files under directory

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

