### PR TITLE
[Dual-ToR] do not allow to start mux container if Dual-ToR was not configured

### DIFF
--- a/files/scripts/write_standby.py
+++ b/files/scripts/write_standby.py
@@ -2,6 +2,7 @@
 
 import argparse
 import time
+import sys
 
 from sonic_py_common import logger as log
 from swsscommon.swsscommon import ConfigDBConnector, DBConnector, FieldValuePairs, ProducerStateTable, SonicV2Connector, Table
@@ -160,8 +161,8 @@ class MuxStateWriter(object):
         Writes standby mux state to APP DB for all mux interfaces
         """
         if not self.is_dualtor:
-            # If not running on a dual ToR system, take no action
-            return
+            logger.log_warning("It is not a Dual-ToR system, do not start mux container")
+            sys.exit(1)
 
         if self.is_warmrestart and self.is_shutdwon:
             # If in warmrestart context, take no action


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Need to improve logic where the system decides to start Dual-ToR or not

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
In [mux.service.j2](https://github.com/sonic-net/sonic-buildimage/blob/master/files/build_templates/mux.service.j2) we have a few scripts that are executed before starting the mux container (ExecStartPre):
```
[Service]
TimeoutStartSec=180
User={{ sonicadmin_user }}
ExecStartPre=/usr/local/bin/write_standby.py
ExecStartPre=/usr/local/bin/mark_dhcp_packet.py
ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
ExecStart=/usr/bin/{{docker_container_name}}.sh wait
```
If any of **ExecStartPre** scripts have a non-zero exit code mux.sh will not start.
But currently, we always return 0.
The suggestion is to exit with code 1 when the system **is not configured with Dual-ToR sybtype** in DEVICE_METADATA [write_standby.py#L85 ](https://github.com/sonic-net/sonic-buildimage/blob/master/files/scripts/write_standby.py#L85) . 

#### How to verify it
1) Config switch with Dual-ToR config
2) make sure mux docker up and running
3) remove` "subtype": "DualToR"` from DEVICE_METADATA
4) config reload -y
===> mux docker is down

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

